### PR TITLE
Add wikipedia service

### DIFF
--- a/fabulous/services/wikipedia.py
+++ b/fabulous/services/wikipedia.py
@@ -1,0 +1,64 @@
+"""~wiki <search term> will return three results from the wikipedia search for <search term>"""
+
+import re
+import requests
+
+def wiki_search(query, results=3, suggestion=True):
+    params = {
+        'format': 'json',
+        'action': 'query',
+        'list': 'search',
+        'srprop': 'snippet',
+        'srlimit': results,
+        'srsearch': query,
+        'generator': 'search',
+        'gsrlimit': results,
+        'gsrsearch': query,
+        'prop': 'info',
+        'inprop': 'url',
+    }
+    if suggestion:
+        params['srinfo'] = 'suggestion'
+
+    r = requests.get('http://en.wikipedia.org/w/api.php', params=params)
+
+    raw_results = r.json()
+
+    if 'error' in raw_results:
+        if raw_results['error']['info'] in ('HTTP request timed out.', 'Pool queue is full'):
+            return u"Searching for \"{0}\" resulted in a timeout. Try again in a few seconds.".format(self.query)
+        else:
+            return "An unknown error occured: \"{0}\".".format(raw_results['error']['info'])
+
+    try:
+        # Python 2.6-2.7 
+        from HTMLParser import HTMLParser
+    except ImportError:
+        # Python 3
+        from html.parser import HTMLParser
+    h = HTMLParser()
+
+    search_results = list(
+            (d['title'],
+            h.unescape(re.sub('^Play media\s*', '', re.sub('<[^<]+?>', '', d['snippet']))),
+            raw_results['query']['pages'][str(d['pageid'])]['fullurl'])
+        for d in raw_results['query']['search'])
+
+    if suggestion and not search_results:
+        if raw_results['query'].get('searchinfo'):
+            return [u'Did you mean: {}?'.format(raw_results['query']['searchinfo']['suggestion'])]
+        return [u'Found nothing :(']
+
+    return list(u'{} {}\n{}...'.format(x, z, y) for (x, y, z) in search_results)
+
+def on_message(msg, server):
+    text = msg.get("text", "")
+    match = re.findall(r"~wiki (.*)", text)
+    if not match:
+        return
+
+    searchterm = match[0]
+    return "\n\n".join(wiki_search(searchterm))
+
+
+on_bot_message = on_message


### PR DESCRIPTION
Proposed fix to #13

I used https://github.com/goldsmith/Wikipedia as an example and https://www.mediawiki.org/wiki/Special:ApiSandbox for checking requests to API.

How it works:
- script requests wiki for 3 top search results
- if there are any results script shows its title, url to the page and short description (description is trimmed of html tags and "Play media" string at the beginning)
- if there is no result, script return suggestion
- if there is no suggestion to return then it excuses itself with 'Found nothing :(' string

Known issues:
- Slack won't show preview for the link that already have been posted in channel last hour so I added short description to output
- Search works only in English wikipedia. I need help in making decision how to add multi language support

Example of work:
<img width="691" alt="screen shot 2017-10-17 at 12 10 21" src="https://user-images.githubusercontent.com/12728509/31656424-3235b06c-b334-11e7-852a-ad8f6240ba49.png">
